### PR TITLE
Update install-kube-u22-wg.sh (#34)

### DIFF
--- a/k8s/install-kube-u22-wg.sh
+++ b/k8s/install-kube-u22-wg.sh
@@ -94,7 +94,7 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.
 
 # Check for lock
 Check_lock
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg || { log_print ERROR "Kubernetes repo can't be added!"; exit $EXITCODE; }
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg || { log_print ERROR "Kubernetes repo can't be added!"; exit $EXITCODE; }
 sudo apt-get update
 
 # Check for lock


### PR DESCRIPTION
https://pkgs.k8s.io/core:/stable:/v1.26/deb/Release.key got expired on 2024/11/02. Switching to https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key